### PR TITLE
Small spelling mistake.

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -68,7 +68,7 @@
 
             <p>
               <span lang="es">¿Qué tal?</span>
-              I’m the Design Alpaca. I care about accessability and ease of use of our websites and apps.
+              I’m the Design Alpaca. I care about accessibility and ease of use of our websites and apps.
             </p>
           </div>
         </div>


### PR DESCRIPTION
The correct word is `accessibility` and not `accessability`.
